### PR TITLE
Feature/mamarsh525/frontend render url support

### DIFF
--- a/src/main/java/org/example/photoalbum/Controllers/AlbumController.java
+++ b/src/main/java/org/example/photoalbum/Controllers/AlbumController.java
@@ -25,7 +25,7 @@ import org.springframework.web.server.ResponseStatusException;
 
 import jakarta.servlet.http.HttpServletRequest;
 
-@CrossOrigin(origins = "http://localhost:5173")
+@CrossOrigin(origins = {"http://localhost:5173", "https://front-end-1qk9.onrender.com"})
 @RestController
 @RequestMapping("/api/albums")
 public class AlbumController {

--- a/src/main/java/org/example/photoalbum/Controllers/UserController.java
+++ b/src/main/java/org/example/photoalbum/Controllers/UserController.java
@@ -19,7 +19,7 @@ import org.springframework.web.server.ResponseStatusException;
 
 import jakarta.servlet.http.HttpServletRequest;
 
-@CrossOrigin(origins = "http://localhost:5173")
+@CrossOrigin(origins = {"http://localhost:5173", "https://front-end-1qk9.onrender.com"})
 @RestController
 @RequestMapping("/api/users")
 public class UserController {

--- a/src/main/java/org/example/photoalbum/config/CorsConfig.java
+++ b/src/main/java/org/example/photoalbum/config/CorsConfig.java
@@ -10,7 +10,7 @@ public class CorsConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins("http://localhost:5173")
+                .allowedOrigins("http://localhost:5173", "https://front-end-1qk9.onrender.com")
                 .allowedMethods("GET","POST","PUT","PATCH","DELETE","OPTIONS")
                 .allowedHeaders("Authorization","Content-Type")
                 .exposedHeaders("Authorization");

--- a/src/main/java/org/example/photoalbum/security/FirebaseAuthFilter.java
+++ b/src/main/java/org/example/photoalbum/security/FirebaseAuthFilter.java
@@ -27,7 +27,10 @@ public class FirebaseAuthFilter extends OncePerRequestFilter {
             FilterChain filterChain
     ) throws ServletException, IOException {
 
-        response.setHeader("Access-Control-Allow-Origin", "http://localhost:5173");
+        String origin = request.getHeader("Origin");
+        if ("http://localhost:5173".equals(origin) || "https://front-end-1qk9.onrender.com".equals(origin)) {
+            response.setHeader("Access-Control-Allow-Origin", origin);
+        }
         response.setHeader("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS");
         response.setHeader("Access-Control-Allow-Headers", "Authorization, Content-Type");
         response.setHeader("Access-Control-Expose-Headers", "Authorization");


### PR DESCRIPTION
- Added `https://front-end-1qk9.onrender.com` to allowed origins in `CorsConfig.java` and both controller `@CrossOrigin` annotations
- Fixed `FirebaseAuthFilter` which was hardcoding `localhost:5173` in the `Access-Control-Allow-Origin` response header, overriding all other CORS config for non-OPTIONS requests
